### PR TITLE
List saving fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/*
+.history

--- a/build.html
+++ b/build.html
@@ -1,5 +1,5 @@
 {{#if items.length}}
-<div data-list-thumb-l-id="{{id}}" data-filter-id="{{id}}" data-list-uuid="{{uuid}}" class="list list-thumb-l {{#if swipeToSave}}list-swipe-save{{/if}}">
+<div data-list-thumb-l-id="{{id}}" data-filter-id="{{id}}" data-list-uuid="{{uuid}}" data-list-thumb-s-uuid="{{uuid}}" class="list list-thumb-l {{#if swipeToSave}}list-swipe-save{{/if}}">
   {{#if swipeToSave}}
   <div class="filter-wrapper">
     <ul class="list-save-filter">

--- a/build.html
+++ b/build.html
@@ -1,5 +1,5 @@
 {{#if items.length}}
-<div data-list-thumb-l-id="{{id}}" data-filter-id="{{id}}" data-list-thumb-s-uuid="{{uuid}}" class="list list-thumb-l {{#if swipeToSave}}list-swipe-save{{/if}}">
+<div data-list-thumb-l-id="{{id}}" data-filter-id="{{id}}" data-list-uuid="{{uuid}}" class="list list-thumb-l {{#if swipeToSave}}list-swipe-save{{/if}}">
   {{#if swipeToSave}}
   <div class="filter-wrapper">
     <ul class="list-save-filter">

--- a/css/build.css
+++ b/css/build.css
@@ -47,10 +47,6 @@
 	padding: 10px 10px 10px 86px;
 	position: relative;
 	min-height: 71px;
-	display: flex;
-	justify-content: center;
-	align-content: center;
-	flex-direction: column;
 }
 
 .list.list-thumb-l ul > li .list-swipe-wrapper {


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue

https://github.com/Fliplet/fliplet-studio/issues/3961

## Description

Remove display flex witch overlapped display none from MixItUp.
Change data-list-thumb-s-uuid to data-list-uuid to fix multiple component's behaviors on the same screen.

## Screenshots/screencasts

![issue-3961](https://user-images.githubusercontent.com/53430352/62916489-6269dc80-bda1-11e9-899b-f63b2c211964.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes

Change the data attribute so there is no need to change the list-swipe library.